### PR TITLE
FIxed build date added to NG builds DB

### DIFF
--- a/APSIM.Builds.Service/Builds.svc.cs
+++ b/APSIM.Builds.Service/Builds.svc.cs
@@ -43,8 +43,8 @@ namespace APSIM.Builds.Service
                     string sql = "INSERT INTO ApsimX (Date, PullRequestID, IssueNumber, IssueTitle, Released) " +
                                  "VALUES (@Date, @PullRequestID, @IssueNumber, @IssueTitle, @Released)";
 
-                    DateTime date = DateTime.Now;
                     PullRequest pull = GitHubUtilities.GetPullRequest(pullRequestNumber, owner, repo);
+                    DateTime date = pull.GetTestDate(owner, repo);
                     pull.GetIssueDetails(out int issueNumber, out bool released);
                     string issueTitle = pull.GetIssueTitle(owner, repo);
                     using (SqlCommand command = new SqlCommand(sql, connection))


### PR DESCRIPTION
This needs to be the same as the date on which the installers/autodocs were built,
in order for the version stamp to be consistent.